### PR TITLE
Make look in default db support longdescs

### DIFF
--- a/data/prototype_db.dump
+++ b/data/prototype_db.dump
@@ -458,9 +458,19 @@ void main(const string &in args)
     {
       println(entity.get_name(true));
     }
-    
-    string@ desc = entity.get_string_prop("/look/shortdesc");
-    println(desc);
+    if (entity.is_prop_document("/look/longdesc"))
+    {
+        array<string> @desc = entity.get_document_prop("/look/longdesc/");
+        for (uint index = 0; index < desc.length(); ++index)
+        {
+            println(desc[index]);
+        }
+    }
+    else
+    {
+        string@ desc = entity.get_string_prop("/look/shortdesc");
+        println(desc);
+    }
     
     array<Entity> @contents = entity.get_contents();
     


### PR DESCRIPTION
Getting back into it and beginning to design a development MUCK ('Explorers of Xul'Quon'). Wanted to support wordy descriptions, so this seemed intuitive. Trivial change just to get used to angelscript's flow.

If you have a different, particular behavior in mind for `look` we should probably do that before we get too used to things, though.