### PR TITLE
#10 quick ref update

### DIFF
--- a/src/comminterface/comm_RouterSessionManager.cpp
+++ b/src/comminterface/comm_RouterSessionManager.cpp
@@ -675,17 +675,12 @@ namespace comm
     {
         bool do_shutdown = false;
         bool more_work = false;
-        timeval current_idle_check_time;
-        timeval prev_idle_check_time;
-        timespec start_time;
-        timespec end_time;
-        timespec time_diff;
-        timespec time_to_wait;
-
-        time_to_wait.tv_sec = 0;
-        time_to_wait.tv_nsec = 0;
-        prev_idle_check_time.tv_sec = 0;
-        prev_idle_check_time.tv_usec = 0;
+        timeval current_idle_check_time = {};
+        timeval prev_idle_check_time = {};
+        timespec start_time = {};
+        timespec end_time = {};
+        timespec time_diff = {};
+        timespec time_to_wait = {};
 
         if (clock_gettime(CLOCK_MONOTONIC, &start_time))
         {
@@ -803,12 +798,13 @@ namespace comm
                 // last calls took.  This cannot be negative due to the clock
                 // type we are using.
                 //
-                osinterface::TimeUtils::timespec_substract(
-                    end_time,
-                    start_time,
-                    time_diff);
+                const bool is_negative =
+                    osinterface::TimeUtils::timespec_substract(
+                        end_time,
+                        start_time,
+                        time_diff);
 
-                if ((not time_diff.tv_sec) and
+                if ((not is_negative) and (not time_diff.tv_sec) and
                     (time_diff.tv_nsec < DEFAULT_SLEEP_TIME_NANOSEC))
                 {
                     // Did not take more time than the periodic sleep, so

--- a/src/dbinterface/dbinterface_DatabaseAccess.cpp
+++ b/src/dbinterface/dbinterface_DatabaseAccess.cpp
@@ -103,6 +103,14 @@ namespace dbinterface
     }
 
     // ----------------------------------------------------------------------
+    void DatabaseAccess::os_time_has_jumped(bool backwards)
+    {
+        // Just pass this along for now, until an actual listener
+        // infrastructure is made.
+        UpdateManager::instance()->os_time_has_jumped(backwards);
+    }
+
+    // ----------------------------------------------------------------------
     void DatabaseAccess::add_entity_listener(
         DatabaseEntityListener * const listener_ptr)
     {

--- a/src/dbinterface/dbinterface_DatabaseAccess.h
+++ b/src/dbinterface/dbinterface_DatabaseAccess.h
@@ -5,6 +5,8 @@
 #include <set>
 #include <vector>
 
+#include "osinterface/osinterface_TimeJumpListener.h"
+
 #include "dbtypes/dbtype_Id.h"
 #include "dbinterface_EntityRef.h"
 #include "dbinterface/dbinterface_DbBackend.h"
@@ -34,7 +36,7 @@ namespace dbinterface
      * etc).  Generally, it will instantiate the DB backend, UpdateManager,
      * and any other classes needed to manage the database.
      */
-    class DatabaseAccess
+    class DatabaseAccess : public osinterface::TimeJumpListener
     {
     public:
         /**
@@ -68,6 +70,13 @@ namespace dbinterface
          * Shuts down the singleton instance; called when MUTGOS is coming down.
          */
         void shutdown(void);
+
+        /**
+         * Called when a massive (more than a few seconds) system time jump has
+         * been detected.
+         * @param backwards[in] True if the jump was backwards.
+         */
+        virtual void os_time_has_jumped(bool backwards);
 
         /**
          * Adds a DatabaseEntityListener.

--- a/src/dbtypes/dbtype_TimeStamp.h
+++ b/src/dbtypes/dbtype_TimeStamp.h
@@ -125,7 +125,7 @@ namespace dbtype
 
         /**
          * @return The TimeStamp in a format suitable for display in a
-         * standarized way.
+         * standarized way.  It will be in local time.
          */
         std::string format_time_stamp(void) const;
 
@@ -142,8 +142,27 @@ namespace dbtype
 
         /**
          * @return Returns how many seconds ago from 'now' this timestamp is.
+         * If negative, this will return 0.
          */
         MG_LongUnsignedInt get_relative_seconds(void) const;
+
+        /**
+         * @param negative[out] True if seconds are actually negative.
+         * @return Returns how many seconds ago from 'now' this timestamp is.
+         * This will be the absolute value if negative.
+         */
+        MG_LongUnsignedInt get_relative_seconds(bool &negative) const;
+
+        /**
+         * @param other[in] The timestamp to compare against, presumed
+         * to be 'newer' and will be what this timestamp subtracts.
+         * @param negative[out] True if seconds are actually negative.
+         * @return Returns how many seconds ago from other this timestamp is.
+         * This will be the absolute value if negative.
+         */
+        MG_LongUnsignedInt get_relative_seconds(
+            const TimeStamp &other,
+            bool &negative) const;
 
         /**
          * Compares against another TimeStamp.

--- a/src/events/events_EventQueueProcessor.cpp
+++ b/src/events/events_EventQueueProcessor.cpp
@@ -72,6 +72,7 @@ namespace events
             event_queue_semaphore.post();
 
             thread_ptr.load()->join();
+            delete thread_ptr.load();
             thread_ptr.store(0);
         }
     }

--- a/src/executor/executor_ExecutorAccess.cpp
+++ b/src/executor/executor_ExecutorAccess.cpp
@@ -80,6 +80,13 @@ namespace executor
     }
 
     // ----------------------------------------------------------------------
+    void ExecutorAccess::os_time_has_jumped(bool backwards)
+    {
+        // Pass-through for now
+        process_scheduler.os_time_has_jumped(backwards);
+    }
+
+    // ----------------------------------------------------------------------
     PID ExecutorAccess::add_process(
         const dbtype::Id &executable_id,
         const dbtype::Id &owner_id,

--- a/src/executor/executor_ExecutorAccess.h
+++ b/src/executor/executor_ExecutorAccess.h
@@ -6,6 +6,8 @@
 #include <boost/thread/thread.hpp>
 
 #include "osinterface/osinterface_OsTypes.h"
+#include "osinterface/osinterface_TimeJumpListener.h"
+
 #include "dbtypes/dbtype_Id.h"
 
 #include "executor/executor_CommonTypes.h"
@@ -35,7 +37,7 @@ namespace executor
      * Processes that are actively running need to use the provided
      * ExecutionInterface to communicate with the Executor, instead.
      */
-    class ExecutorAccess
+    class ExecutorAccess : public osinterface::TimeJumpListener
     {
     public:
 
@@ -74,6 +76,13 @@ namespace executor
          * Not thread safe.
          */
         void shutdown(void);
+
+        /**
+         * Called when a massive (more than a few seconds) system time jump has
+         * been detected.
+         * @param backwards[in] True if the jump was backwards.
+         */
+        virtual void os_time_has_jumped(bool backwards);
 
         /**
          * Adds the given process to the Executor.  The process will not

--- a/src/executor/executor_ProcessInfo.cpp
+++ b/src/executor/executor_ProcessInfo.cpp
@@ -1,10 +1,10 @@
 
 #include <string>
+#include <chrono>
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
 #include "text/text_StringConversion.h"
-#include <boost/date_time/microsec_time_clock.hpp>
 
 #include "executor/executor_ProcessInfo.h"
 #include "executor/executor_ProcessMessage.h"
@@ -420,7 +420,7 @@ namespace executor
     }
 
     // ----------------------------------------------------------------------
-    ProcessInfo::WakeupTimeUTC ProcessInfo::get_utc_wakeup_time(
+    ProcessInfo::WakeupTimePoint ProcessInfo::get_wakeup_time(
         concurrency::ReaderLockToken &token)
     {
         if (token.has_lock(*this))
@@ -429,20 +429,20 @@ namespace executor
         }
         else
         {
-            LOG(fatal, "executor", "get_utc_wakeup_time",
+            LOG(fatal, "executor", "get_wakeup_time",
                 "Using the wrong lock token!  PID "
                 + text::to_string(my_pid));
         }
 
-        return WakeupTimeUTC();
+        return std::chrono::steady_clock::now();
     }
 
     // ----------------------------------------------------------------------
-    ProcessInfo::WakeupTimeUTC ProcessInfo::get_utc_wakeup_time(void)
+    ProcessInfo::WakeupTimePoint ProcessInfo::get_wakeup_time(void)
     {
         concurrency::ReaderLockToken token(*this);
 
-        return get_utc_wakeup_time(token);
+        return get_wakeup_time(token);
     }
 
     // ----------------------------------------------------------------------
@@ -453,8 +453,8 @@ namespace executor
         if (token.has_lock(*this))
         {
             wakeup_time =
-                boost::posix_time::microsec_clock::universal_time()
-                  + boost::posix_time::millisec(offset_ms);
+                std::chrono::steady_clock::now()
+                  + std::chrono::milliseconds(offset_ms);
 
             return true;
         }

--- a/src/executor/executor_ProcessInfo.h
+++ b/src/executor/executor_ProcessInfo.h
@@ -4,8 +4,8 @@
 #include <string>
 #include <queue>
 #include <set>
+#include <chrono>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 
 #include "concurrency/concurrency_LockableObject.h"
@@ -67,8 +67,8 @@ namespace executor
             PROCESS_STATE_END_INVALID
         };
 
-        /** Absolute wakeup time in UTC */
-        typedef boost::posix_time::ptime WakeupTimeUTC;
+        /** Absolute wakeup time in monotonic clock time */
+        typedef std::chrono::steady_clock::time_point WakeupTimePoint;
 
         /**
          * Converts the given process state to a string.
@@ -324,17 +324,17 @@ namespace executor
          * This does not check the current process state, so it will return
          * a wakeup time in the past if the wakeup already happened.
          * @param token[in] The lock token.
-         * @return The absolute time, in UTC, for a sleeping process to wakeup.
+         * @return The steady clock time point for a sleeping process to wakeup.
          */
-        WakeupTimeUTC get_utc_wakeup_time(concurrency::ReaderLockToken &token);
+        WakeupTimePoint get_wakeup_time(concurrency::ReaderLockToken &token);
 
         /**
          * This does not check the current process state, so it will return
          * a wakeup time in the past if the wakeup already happened.
          * This method will automatically get a lock.
-         * @return The absolute time, in UTC, for a sleeping process to wakeup.
+         * @return The steady clock time point for a sleeping process to wakeup.
          */
-        WakeupTimeUTC get_utc_wakeup_time(void);
+        WakeupTimePoint get_wakeup_time(void);
 
         /**
          * Sets the absolute sleep time to be now + offset.
@@ -664,7 +664,7 @@ namespace executor
         bool pending_suspended; ///< True if process suspension has been requested
         bool daemon; ///< True if a process is a daemon (not cleaned up) TODO remove
 
-        WakeupTimeUTC wakeup_time; ///< If sleeping, when wakeup occurs
+        WakeupTimePoint wakeup_time; ///< If sleeping, when wakeup occurs
 
         MessageQueue waiting_messages; ///< ProcessMessages sent to process
 

--- a/src/osinterface/osinterface_TimeJumpListener.h
+++ b/src/osinterface/osinterface_TimeJumpListener.h
@@ -1,0 +1,47 @@
+/*
+ * osinterface_TimeJumpListener.h
+ */
+
+#ifndef MUTGOS_OSINTERFACE_TIMEJUMPLISTENER_H
+#define MUTGOS_OSINTERFACE_TIMEJUMPLISTENER_H
+
+namespace mutgos
+{
+namespace osinterface
+{
+    /**
+     * An interface that notifies the listener when an OS-level 'time jump'
+     * has occurred.  This can happen because the user manually set the
+     * system clock backwards or forwards a significant amount, or perhaps
+     * NTP misconfiguration.
+     *
+     * Since some Boost calls require absolute time, they may not return from
+     * their timed wait when expected if time were to go backwards a
+     * significant amount.
+     */
+    class TimeJumpListener
+    {
+    public:
+        /**
+         * Default instructor.
+         */
+        TimeJumpListener(void)
+          { }
+
+        /**
+         * Destructor.
+         */
+        virtual ~TimeJumpListener()
+          { }
+
+        /**
+         * Called when a massive (more than a few seconds) system time jump has
+         * been detected.
+         * @param backwards[in] True if the jump was backwards.
+         */
+        virtual void os_time_has_jumped(bool backwards) =0;
+    };
+}
+}
+
+#endif //MUTGOS_OSINTERFACE_TIMEJUMPLISTENER_H


### PR DESCRIPTION
Fixes #10 

The update thread now processes 'contained by' changes immediately rather than wait until the  database commit cycle.  This will make any Entity that's moved (dropped, picked up, use an exit, etc) appear in the contents of its new location immediately.

Also made a side fix to prevent sudden system time jumps from hanging threads, which might prevent Entities from being saved to the DB or keep a shutdown from succeeding.