### PR TITLE
#6 #7 utf8 string limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,7 @@ RUN if [ ! -f /home/mutgos/data/key.pem ] || [ ! -f /home/mutgos/data/cert.pem ]
 # Build the db and put it in the right place.
 RUN if [ ! -f /home/mutgos/data/mutgos.db ]; then \
         cd /home/mutgos/src/exe/read_dump \
-        && ./readdump /home/mutgos/data/prototype_db.dump \
-        && cp ./mutgos.db /home/mutgos/data/ \
+        && ./readdump --configfile /home/mutgos/data/mutgos.conf --dumpfile /home/mutgos/data/prototype_db.dump \
     ; fi
 
 

--- a/data/mutgos.conf.sample
+++ b/data/mutgos.conf.sample
@@ -31,10 +31,12 @@ executor.thread_count=2
 # Maximum time to wait, in seconds, for a connection (any) to
 # authenticate (log in) before automatically disconnecting them.
 connection.auth_time=300
+
 # Maximum time an authenticated connection can be idle (no activity from
 # client), in seconds.  This is temporary and will eventually be tunable per
 # site.
 connection.idle_time=7200
+
 # Maximum time, in seconds, that an improperly disconnected client
 # (connection blip, etc) has to reconnect and maintain their existing session.
 # If the time expires, they will be disconnected in game and any pending
@@ -44,28 +46,37 @@ connection.reconnect_wait_time=300
 # Maximum length of a single line input by a user, in bytes.  Anything longer
 # than this will either be rejected or cut off.
 connection.socket.input_line_length=8192
+
 # True to enable the SSL (encrypted) port.
 connection.socket.enable_ssl=true
+
 # True to enable the unencrypted (plaintext) port.
 connection.socket.enable_plain=true
+
 # The port to listen on for unencrypted socket connections.
 connection.socket.port=7072
+
 # The port to listen on for SSL (encrypted) socket connections.
 connection.socket.port_ssl=7073
+
 # If using SSL, this specifies the certificate file, in PEM format.
 connection.certificate_file=cert.pem
+
 # If using SSL, this specifies the private key file, in PEM format.
 # This may be the same file as the certificate itself.
 connection.certificate_private_key_file=key.pem
 
 # True to enable websocket support.
 connection.websocket.enable=true
+
 # What port the websocket will listen on locally (127.0.0.1) for proxied
 # connections.
 connection.websocket.port=7000
+
 # Maximum window size (pending messages).  This should normally not be adjusted
 # unless there are connection performance problems or memory usage issues.
 connection.websocket.max_window=8192
+
 # Maximum size of a websocket message coming from a client, in bytes.
 # This should normally not need to be adjusted.
 connection.websocket.max_incoming_message_size=16384
@@ -77,10 +88,35 @@ connection.websocket.max_incoming_message_size=16384
 
 # Specifies the SQLite database file.
 database.db_file=mutgos.db
+
 # How encrypted (via bcrypt) the Player passwords are.  Higher values will take
 # significantly longer (about a factor of 2x for every +1). This value may be
 # safely changed without invalidating existing passwords.
 database.password_workfactor=10
+
+# Unless overriden by other properties, the default max length for any string
+# stored in the database.  All string lengths in this section are measured in
+# UTF8 code points, not bytes.
+database.limits.string=4096
+
+# Max string length for an entity name, unless overridden.
+database.limits.entity.name=128
+
+# Max string length for a player or puppet name.
+database.limits.player_puppet.name=32
+
+# Max string length for a property name.  This is not the full path, just an
+# element of the path.
+database.limits.property.name=64
+
+# Maximum number of items in a property value set.
+database.limits.property.set.items=4096
+
+# Maximum number of lines in a non-program property value document.
+database.limits.property.document.lines=1024
+
+# Maximum number of lines in a program document.
+database.limits.program.lines=32768
 
 
 ########################################
@@ -98,3 +134,7 @@ angelscript.timeslice=300
 # if the pool is empty, but the pool will never contain more than the
 # count below.
 angelscript.max_pool_size=4
+
+# Maximum size for a runtime string in AngleScript.  This is measured in
+# UTF8 code points, not bytes.
+angelscript.max_string_length=32768

--- a/data/prototype_db.dump
+++ b/data/prototype_db.dump
@@ -117,8 +117,12 @@ mkentity program $ps_prog
     program_source_code=lines 30
 void main(const string &in args)
 {
-  string psOutput = SystemOps::get_formatted_processes();  
-  mprintln(psOutput);
+  array<string> @ps_output = SystemOps::get_formatted_processes();  
+    
+  for (uint index = 0; index < ps_output.length(); ++index)
+  {
+      println(ps_output[index]);
+  }
 }
 .end
   end fields
@@ -134,7 +138,7 @@ mkentity command $ps_command
   fields
     action_contained_by=$global_root_region
     action_targets=$ps_prog
-	action_commands=@ps
+    action_commands=@ps
   end fields
 end entity
 ####
@@ -231,7 +235,7 @@ mkentity command $who_command
   fields
     action_contained_by=$global_root_region
     action_targets=$who_prog
-	action_commands=who
+    action_commands=who
   end fields
 end entity
 ####
@@ -263,7 +267,12 @@ void main(const string &in args)
   if (entity.is_valid())
   {
     // Matched by ID.
-    mprintln(entity.to_string());
+    array<string> @examine_details = entity.to_string();
+    
+    for (uint index = 0; index < examine_details.length(); ++index)
+    {
+        println(examine_details[index]);
+    }
   }
   else
   {
@@ -289,7 +298,12 @@ void main(const string &in args)
     else
     {
       // Found it!
-      mprintln(entity.to_string());
+      array<string> @examine_details = entity.to_string();
+        
+      for (uint index = 0; index < examine_details.length(); ++index)
+      {
+          println(examine_details[index]);
+      }
     }
   }
 }
@@ -304,7 +318,7 @@ mkentity command $examine_command
     action_targets=$examine_prog
     action_commands=ex
     action_commands=exam
-	action_commands=examine
+    action_commands=examine
   end fields
 end entity
 ####
@@ -339,8 +353,8 @@ mkentity command $say_command
   fields
     action_contained_by=$global_root_region
     action_targets=$say_prog
-	action_commands=say
-	action_commands="
+    action_commands=say
+    action_commands="
   end fields
 end entity
 ####
@@ -395,8 +409,8 @@ mkentity command $pose_command
   fields
     action_contained_by=$global_root_region
     action_targets=$pose_prog
-	action_commands=pose
-	action_commands=:
+    action_commands=pose
+    action_commands=:
   end fields
 end entity
 ####
@@ -550,7 +564,7 @@ mkentity command $look_command
   fields
     action_contained_by=$global_root_region
     action_targets=$look_prog
-	action_commands=look
+    action_commands=look
   end fields
 end entity
 ####
@@ -619,7 +633,7 @@ void main(const string &in args)
   
   if (clear)
   {
-	entity.set_prop("/look/shortdesc", "");
+    entity.set_prop("/look/shortdesc", "");
   }
   else
   {
@@ -638,10 +652,10 @@ mkentity command $desc_command
   fields
     action_contained_by=$global_root_region
     action_targets=$desc_prog
-	action_commands=@description
-	action_commands=@desc
-	action_commands=@setdesc
-	action_commands=@setdescription
+    action_commands=@description
+    action_commands=@desc
+    action_commands=@setdesc
+    action_commands=@setdescription
   end fields
 end entity
 ####
@@ -689,7 +703,7 @@ void main(const string &in args)
       
       for (uint index = 0; index < items.length(); ++index)
       {
-		formattedItems.append_entity(items[index]);
+        formattedItems.append_entity(items[index]);
         fprintln(formattedItems);
       }
     }
@@ -704,9 +718,9 @@ mkentity command $inventory_command
   fields
     action_contained_by=$global_root_region
     action_targets=$inventory_prog
-	action_commands=i
-	action_commands=inv
-	action_commands=inventory
+    action_commands=i
+    action_commands=inv
+    action_commands=inventory
   end fields
 end entity
 ####
@@ -752,7 +766,7 @@ mkentity command $create_command
   fields
     action_contained_by=$global_root_region
     action_targets=$create_prog
-	action_commands=@create
+    action_commands=@create
   end fields
 end entity
 ####
@@ -819,9 +833,9 @@ mkentity command $delete_command
   fields
     action_contained_by=$global_root_region
     action_targets=$delete_prog
-	action_commands=@delete
-	action_commands=@recycle
-	action_commands=@rec
+    action_commands=@delete
+    action_commands=@recycle
+    action_commands=@rec
   end fields
 end entity
 ####
@@ -904,7 +918,7 @@ mkentity command $drop_command
   fields
     action_contained_by=$global_root_region
     action_targets=$drop_prog
-	action_commands=drop
+    action_commands=drop
   end fields
 end entity
 ####
@@ -987,8 +1001,8 @@ mkentity command $get_command
   fields
     action_contained_by=$global_root_region
     action_targets=$get_prog
-	action_commands=get
-	action_commands=pickup
+    action_commands=get
+    action_commands=pickup
   end fields
 end entity
 ####
@@ -1069,8 +1083,8 @@ mkentity command $page_command
   fields
     action_contained_by=$global_root_region
     action_targets=$page_prog
-	action_commands=page
-	action_commands=p
+    action_commands=page
+    action_commands=p
   end fields
 end entity
 ####
@@ -1216,7 +1230,7 @@ mkentity command $security_command
   fields
     action_contained_by=$global_root_region
     action_targets=$security_prog
-	action_commands=@security
+    action_commands=@security
   end fields
 end entity
 ####
@@ -1363,7 +1377,7 @@ mkentity command $looksecurity_command
   fields
     action_contained_by=$global_root_region
     action_targets=$looksecurity_prog
-	action_commands=@looksecurity
+    action_commands=@looksecurity
   end fields
 end entity
 ####
@@ -1450,7 +1464,7 @@ mkentity command $admin_player_action
   fields
     action_contained_by=$admin_player
     action_targets=$admin_player_prog
-	action_commands=runprog
+    action_commands=runprog
   end fields
 end entity
 
@@ -1546,7 +1560,7 @@ mkentity exit $room1_exit
     action_succ_msg=You head to the light!
     action_succ_room_msg=heads out to the light.
     exit_arrive_room_msg=arrives from the root of everything.
-	action_commands=o
+    action_commands=o
     action_commands=out
   end fields
 end entity
@@ -1558,7 +1572,7 @@ mkentity command $run_prog_command
   fields
     action_contained_by=$root_region
     action_targets=$hello_prog
-	action_commands=h
+    action_commands=h
     action_commands=hello
   end fields
 end entity
@@ -1639,7 +1653,7 @@ mkentity command $normal_player_action
   fields
     action_contained_by=$normal_player
     action_targets=$normal_player_prog
-	action_commands=runprog
+    action_commands=runprog
   end fields
 end entity
 

--- a/docs/howto_compile_run_prototype.txt
+++ b/docs/howto_compile_run_prototype.txt
@@ -74,10 +74,10 @@ Before you can run the server, you need to import a database.  This can be done 
 
   * Find the readdump executable.  Depending on if you had an IDE build it or not, it may be alongside the source code at src/exe/read_dump, or in a parallel directory such as cmake-build-debug/src/exe/read_dump.
   * cd to where the readdump executable is.
-  * Run a command like:  ./readdump /path/to/mutgos/data/prototype_db.dump
+  * Run a command like:  ./readdump --configfile /path/to/mutgos/data/mutgos.conf --dumpfile /path/to/mutgos/data/prototype_db.dump
   * This will import the given dump file.
   * A bunch of text will scroll by, and you should catch something about "Parsing completed successfully.".
-  * Once back at the commandline, copy the resulting mutgos.db file (an SQLITE file) to the data directory you created earlier.
+  * The database file will now exist wherever the MUTGOS config file specified.
 
 
 Generating a SSL Certificate

--- a/src/angelscriptinterface/angelscript_AEntity.h
+++ b/src/angelscriptinterface/angelscript_AEntity.h
@@ -129,10 +129,10 @@ namespace angelscript
         bool is_player(void);
 
         /**
-         * @return Detailed information about the Entity.  There are embedded
-         * newlines.
+         * @return Detailed information about the Entity as an array of
+         * strings.
          */
-        AString *to_string(void);
+        CScriptArray *to_string(void);
 
         /**
          * @return The Entity containing this one, or an exception if

--- a/src/angelscriptinterface/angelscript_AString.h
+++ b/src/angelscriptinterface/angelscript_AString.h
@@ -38,9 +38,6 @@ namespace angelscript
      * call functions on this class; export to an std::string, perform
      * needed operations, then import the result.
      *
-     * TODO UTF-8 support.
-     * TODO Filtering of newlines, etc.
-     * TODO Max string length, regardless of memory.
      * TODO Add 'complexity' metric to do better timesharing
      * TODO Useful post on how someone else did this class:  https://www.gamedev.net/forums/topic/639252-asobj-ref-and-asobj-value-at-the-same-time/?tab=comments#comment-5035942
      */
@@ -103,10 +100,16 @@ namespace angelscript
 
         /**
          * Used by the string factory.
-         * @return The string data as raw bytes.  Use size() to find out how
-         * long the string is.
+         * @return The string data as raw bytes.  Use raw_size() to find out
+         * how long the string is.
          */
         const char *get_raw_data(void) const;
+
+        /**
+         * @return The number of bytes in this string.  Used only in
+         * conjunction with get_raw_data().
+         */
+        StringPos get_raw_size(void) const;
 
         /**
          * Overwrites whatever is in the string with what's supplied.
@@ -164,7 +167,7 @@ namespace angelscript
             const size_t length);
 
         /**
-         * @return The number of characters in this string.
+         * @return The number of characters (UTF8 code points) in this string.
          */
         StringPos size(void) const;
 
@@ -338,7 +341,9 @@ namespace angelscript
          * starting where specified and working backwards.
          * @param str[in] The string to search for.
          * @param pos[in] The position within this string to start searching.
-         * It will work backwards from this position.
+         * It will work backwards from this position and will include the
+         * position in the search.  IE: To search the entire string, pos
+         * would be string size - 1.
          * @return The position where str starts, or the NOT_FOUND constant
          * if the string is not found.
          */
@@ -433,6 +438,15 @@ namespace angelscript
             const size_t line,
             bool &current_result);
 
+        /**
+         * Checks if the size given would exceed the maximum allowed string
+         * size.  If it does, an exception is thrown.
+         * The max size is retrieved from the configuration subsystem.
+         * @param size[in] The size to check.
+         * @throws AngelException if size exceeds max.
+         */
+        void check_exceed_max(const size_t size) const;
+
         // A string with the virtual heap allocator so its allocations
         // are tracked and restricted.
         typedef std::basic_string<
@@ -440,6 +454,7 @@ namespace angelscript
               ManagedString;
 
         ManagedString string_value; ///< The string value
+        StringPos string_size; ///< The UTF-8 aware string size
     };
 }
 }

--- a/src/angelscriptinterface/angelscript_ScriptUtilities.cpp
+++ b/src/angelscriptinterface/angelscript_ScriptUtilities.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <string>
+#include <vector>
 #include <angelscript.h>
 
 #include "logging/log_Logger.h"
@@ -13,6 +14,15 @@
 #include "security/security_Context.h"
 
 #include "angelscript_ScriptContext.h"
+#include "angelscript_AString.h"
+
+#include "text/text_ExternalText.h"
+#include "text/text_ExternalPlainText.h"
+
+#include "primitives/primitives_PrimitivesAccess.h"
+#include "primitives/primitives_SystemPrims.h"
+
+#define TELNET_LF '\n'
 
 namespace
 {
@@ -191,5 +201,108 @@ namespace angelscript
 
         return result;
     }
+
+    // ----------------------------------------------------------------------
+    // TODO Remove once temporary commands gone.  This is not supposed to be used long term.
+    //
+    CScriptArray *ScriptUtilities::multiline_string_to_array(
+        asIScriptEngine * const engine,
+        const std::string &str,
+        const bool exception_on_too_big)
+    {
+        CScriptArray *result = 0;
+        security::Context * const security_context =
+            get_my_security_context(engine);
+
+        text::ExternalTextMultiline external_multiline;
+
+        primitives::PrimitivesAccess::instance()->system_prims().
+            to_external_text_multiline_unformatted(
+                *security_context,
+                str,
+                external_multiline,
+                false);
+
+        // Temporary method, and for now the above call always succeeds.
+        // Not going to implement extensive error checking at this time,
+        // since it's going away.
+
+        AString * astring_line = 0;
+
+        try
+        {
+            result = ScriptUtilities::create_array(
+                engine,
+                "string",
+                external_multiline.size(),
+                exception_on_too_big);
+
+            if (result)
+            {
+                // Create a bunch of AStrings with the data and insert into
+                // the array.
+                //
+                for (text::ExternalTextMultiline::iterator line_iter =
+                        external_multiline.begin();
+                    line_iter != external_multiline.end();
+                    ++line_iter)
+                {
+                    astring_line = new AString(engine);
+                    astring_line->import_from_string(
+                        text::ExternalText::to_string(*line_iter));
+
+                    result->InsertLast(astring_line);
+
+                    // Reference count starts out as 1.  Manually adding it
+                    // to the array will make it 2.  Release our reference.
+                    astring_line->release_ref();
+                    astring_line = 0;
+                }
+            }
+        }
+        catch (std::bad_alloc &ex)
+        {
+            if (result)
+            {
+                result->Release();
+                result = 0;
+            }
+
+            if (astring_line)
+            {
+                astring_line->release_ref();
+            }
+
+            text::ExternalText::clear_text_lines(external_multiline);
+
+            throw;
+        }
+        catch (AngelException &ex)
+        {
+            if (result)
+            {
+                result->Release();
+                result = 0;
+            }
+
+            if (astring_line)
+            {
+                astring_line->release_ref();
+            }
+
+            text::ExternalText::clear_text_lines(external_multiline);
+
+            if (exception_on_too_big)
+            {
+                throw;
+            }
+        }
+
+        text::ExternalText::clear_text_lines(external_multiline);
+
+        return result;
+    }
 }
 }
+
+#undef TELNET_LF

--- a/src/angelscriptinterface/angelscript_ScriptUtilities.h
+++ b/src/angelscriptinterface/angelscript_ScriptUtilities.h
@@ -110,6 +110,20 @@ namespace angelscript
             const size_t initial_size,
             const bool exception_on_too_big);
 
+        /**
+         * Converts a string with embedded newlines into an array, with
+         * each newline indicating a new element.
+         * @param engine[in] The engine running this script.
+         * @param str[in] The string to convert.
+         * @param exception_on_too_big[in] If initial_size is bigger than the
+         * array supports, throw an exception if true, otherwise make it as
+         * big as possible and return.
+         * @return str as an array of strings.
+         */
+        static CScriptArray *multiline_string_to_array(
+            asIScriptEngine * const engine,
+            const std::string &str,
+            const bool exception_on_too_big);
     private:
         // Static-only class
         ScriptUtilities(void);

--- a/src/angelscriptinterface/angelscript_StringFactory.cpp
+++ b/src/angelscriptinterface/angelscript_StringFactory.cpp
@@ -82,7 +82,7 @@ namespace angelscript
                 }
                 else
                 {
-                    *length = (asUINT) astr->size();
+                    *length = (asUINT) astr->get_raw_size();
                 }
             }
             else

--- a/src/angelscriptinterface/angelscript_SystemOps.cpp
+++ b/src/angelscriptinterface/angelscript_SystemOps.cpp
@@ -44,7 +44,7 @@ namespace angelscript
         // Register the functions
         //
         rc = engine.RegisterGlobalFunction(
-            "string@ get_formatted_processes()",
+            "array<string> @get_formatted_processes()",
             asFUNCTION(get_formatted_processes),
             asCALL_GENERIC);
         check_register_rc(rc, __LINE__, result);
@@ -103,7 +103,7 @@ namespace angelscript
 
         // What will be our return value.
         //
-        AString *result_ptr = 0;
+        CScriptArray *result_ptr = 0;
 
         try
         {
@@ -125,20 +125,11 @@ namespace angelscript
             }
             else
             {
-                result_ptr = new AString(engine_ptr);
-                result_ptr->import_from_string(raw_output);
+                result_ptr = ScriptUtilities::multiline_string_to_array(
+                    engine_ptr,
+                    raw_output,
+                    true);
             }
-        }
-        catch (std::bad_alloc &ex)
-        {
-            // String ran out of memory
-            if (result_ptr)
-            {
-                result_ptr->release_ref();
-            }
-
-            ScriptUtilities::set_exception_info(engine_ptr, ex);
-            throw;
         }
         catch (std::exception &ex)
         {
@@ -152,7 +143,7 @@ namespace angelscript
         }
 
         // Return the result
-        *(AString **)gen_ptr->GetAddressOfReturnLocation() = result_ptr;
+        *(CScriptArray **)gen_ptr->GetAddressOfReturnLocation() = result_ptr;
     }
 
     // ----------------------------------------------------------------------
@@ -232,11 +223,21 @@ namespace angelscript
         }
         catch (std::exception &ex)
         {
+            if (result_ptr)
+            {
+                result_ptr->Release();
+            }
+
             ScriptUtilities::set_exception_info(engine_ptr, ex);
             throw;
         }
         catch (...)
         {
+            if (result_ptr)
+            {
+                result_ptr->Release();
+            }
+
             ScriptUtilities::set_exception_info(engine_ptr);
             throw;
         }

--- a/src/dbdump/dbdump_DumpReaderInterface.cpp
+++ b/src/dbdump/dbdump_DumpReaderInterface.cpp
@@ -1784,8 +1784,16 @@ namespace dbdump
         {
             // Valid for setting the property.
             //
-            const dbtype::StringProperty property_data(data);
-            result = property_entity_ptr->set_property(path, property_data);
+            dbtype::StringProperty property_data;
+
+            if (not property_data.set(data))
+            {
+                result = false;
+            }
+            else
+            {
+                result = property_entity_ptr->set_property(path, property_data);
+            }
 
             LOG(result ? debug : error, "dbdump", "set_string_prop",
                 "Set " + path + " : " + property_data.get_as_short_string()

--- a/src/dbdump/dbdump_MutgosDumpFileReader.cpp
+++ b/src/dbdump/dbdump_MutgosDumpFileReader.cpp
@@ -7,6 +7,8 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include "text/text_StringConversion.h"
+#include "text/text_Utf8Tools.h"
+#include "utilities/mutgos_config.h"
 
 #include "dbdump_MutgosDumpFileReader.h"
 #include "dbtypes/dbtype_Id.h"
@@ -114,6 +116,11 @@ namespace dbdump
                 else if (line == "MUTGOS DUMP END")
                 {
                     file_parsed = true;
+                }
+                else if (not text::utf8_valid(line))
+                {
+                    error_condition = true;
+                    message = "Line is not UTF8 compliant.";
                 }
                 else
                 {
@@ -1035,6 +1042,14 @@ namespace dbdump
                 else
                 {
                     current_document_ptr = new dbtype::DocumentProperty();
+
+                    if (current_entity_field ==
+                        dbtype::EntityField::ENTITYFIELD_program_source_code)
+                    {
+                        // Source code gets a longer Document length.
+                        current_document_ptr->set_max_lines(
+                            config::db::limits_program_lines());
+                    }
                 }
             }
             else

--- a/src/dbdump/dbdump_MutgosDumpFileReader.cpp
+++ b/src/dbdump/dbdump_MutgosDumpFileReader.cpp
@@ -120,7 +120,7 @@ namespace dbdump
                 else if (not text::utf8_valid(line))
                 {
                     error_condition = true;
-                    message = "Line is not UTF8 compliant.";
+                    status_message = "Line is not UTF8 compliant.";
                 }
                 else
                 {

--- a/src/dbtypes/dbtype_ActionEntity.cpp
+++ b/src/dbtypes/dbtype_ActionEntity.cpp
@@ -13,15 +13,17 @@
 #include "dbtype_EntityType.h"
 
 #include "logging/log_Logger.h"
+#include "utilities/mutgos_config.h"
 
+#include "text/text_Utf8Tools.h"
 #include "text/text_StringConversion.h"
+
+#define MAX_COMMANDS 64
 
 namespace mutgos
 {
 namespace dbtype
 {
-    // TODO Add code to concatonate actions together to make searching really quick
-
     // ----------------------------------------------------------------------
     ActionEntity::ActionEntity()
       : PropertyEntity(),
@@ -527,6 +529,12 @@ namespace dbtype
     {
         bool result = false;
 
+        if (text::utf8_size(message) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
+
         if (token.has_lock(*this))
         {
             action_entity_succ_msg = message;
@@ -584,6 +592,12 @@ namespace dbtype
         concurrency::WriterLockToken &token)
     {
         bool result = false;
+
+        if (text::utf8_size(message) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
 
         if (token.has_lock(*this))
         {
@@ -644,6 +658,12 @@ namespace dbtype
     {
         bool result = false;
 
+        if (text::utf8_size(message) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
+
         if (token.has_lock(*this))
         {
             action_entity_fail_msg = message;
@@ -701,6 +721,12 @@ namespace dbtype
         concurrency::WriterLockToken &token)
     {
         bool result = false;
+
+        if (text::utf8_size(message) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
 
         if (token.has_lock(*this))
         {
@@ -823,6 +849,21 @@ namespace dbtype
         concurrency::WriterLockToken &token)
     {
         bool result = false;
+
+        if (commands.size() > MAX_COMMANDS)
+        {
+            return false;
+        }
+
+        // Make sure none of the commands are too big
+        for (size_t index = 0; index < commands.size(); ++index)
+        {
+            if (text::utf8_size(commands[index]) >
+                config::db::limits_string_size())
+            {
+                return false;
+            }
+        }
 
         if (token.has_lock(*this))
         {

--- a/src/dbtypes/dbtype_DocumentProperty.h
+++ b/src/dbtypes/dbtype_DocumentProperty.h
@@ -78,13 +78,6 @@ namespace dbtype
         void set_max_lines(const osinterface::OsTypes::UnsignedInt max);
 
         /**
-         * Sets the maximum line string length.  Set this BEFORE adding any
-         * lines.
-         * @param max[in] The maximum line string length.  Must be > 0.
-         */
-        void set_max_line_length(const osinterface::OsTypes::UnsignedInt max);
-
-        /**
          * Creates a clone of the given property data.  Caller must manage
          * returned pointer.
          * @return A pointer to the newly cloned instance of PropertyData.
@@ -162,8 +155,7 @@ namespace dbtype
          * Sets the string data contained by this instance using a string.
          * Newlines will be converted into new line entries.
          * @param str[in] The data to set, as a string.
-         * @return True if successfully set.  It will return true even if the
-         * input has been truncated.
+         * @return True if successfully set.
          */
         virtual bool set_from_string(const std::string &str);
 
@@ -171,20 +163,21 @@ namespace dbtype
          * Sets the string data contained by this instance using a vector
          * of strings.
          * @param data[in] The data to set.
-         * @return True if successfully set.  It will return true even if the
-         * input has been truncated.
+         * @return True if successfully set.
          */
         bool set(const std::vector<std::string> &data);
 
         /**
          * Sets the string data contained by this instance using another
-         * DocumentData instance.
-         * @param data[in] The data to set.
+         * DocumentData instance.  This is for internal use only;
+         * no limit checks are performed.
+         * @param data[in] The data to set.  It will be copied.
          * @return True if successfully set.
          */
         bool set(const DocumentData &data);
 
         /**
+         * Generally for internal use only; not to be exposed to user code.
          * @return The data contained by this DocumentProperty.
          */
         const DocumentData &get(void) const;
@@ -200,7 +193,6 @@ namespace dbtype
 
     private:
 
-        osinterface::OsTypes::UnsignedInt max_string_length; ///< Max Length of strings
         osinterface::OsTypes::UnsignedInt max_lines; ///< Max number of lines
 
         /**
@@ -275,7 +267,6 @@ namespace dbtype
             // serialize base class information
             ar & boost::serialization::base_object<PropertyData>(*this);
 
-            ar & max_string_length;
             ar & max_lines;
             save_document_data(document_data, ar, version);
         }
@@ -288,7 +279,6 @@ namespace dbtype
 
             clear();
 
-            ar & max_string_length;
             ar & max_lines;
             load_document_data(ar, version, document_data);
         }

--- a/src/dbtypes/dbtype_Entity.cpp
+++ b/src/dbtypes/dbtype_Entity.cpp
@@ -11,6 +11,8 @@
 #include "osinterface/osinterface_OsTypes.h"
 
 #include "logging/log_Logger.h"
+#include "utilities/mutgos_config.h"
+#include "text/text_Utf8Tools.h"
 
 #include "dbtypes/dbtype_Entity.h"
 #include "dbtypes/dbtype_EntityType.h"
@@ -447,6 +449,12 @@ namespace dbtype
             return false;
         }
 
+        if (text::utf8_size(name) > config::db::limits_entity_name())
+        {
+            // Exceeds size.
+            return false;
+        }
+
         if (token.has_lock(*this))
         {
             entity_name = name;
@@ -573,6 +581,12 @@ namespace dbtype
         const std::string& note,
         concurrency::WriterLockToken& token)
     {
+        if (text::utf8_size(note) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
+
         if (token.has_lock(*this))
         {
             // Limit the size of the note.
@@ -628,6 +642,12 @@ namespace dbtype
         const std::string &name,
         concurrency::WriterLockToken &token)
     {
+        if (text::utf8_size(name) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
+
         if (token.has_lock(*this))
         {
             // Limit size of the name
@@ -683,6 +703,12 @@ namespace dbtype
         const std::string &category,
         concurrency::WriterLockToken &token)
     {
+        if (text::utf8_size(category) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
+
         if (token.has_lock(*this))
         {
             // Limit size of the category

--- a/src/dbtypes/dbtype_Entity.h
+++ b/src/dbtypes/dbtype_Entity.h
@@ -34,7 +34,6 @@
 #include "dbtypes/dbtype_Security.h"
 #include "dbtypes/dbtype_TimeStamp.h"
 
-// TODO: Create UTF-8 string length truncators and checkers.
 // TODO: Copy_fields()  should only copy anything if it's the right type??
 // TODO: Post-demo: Have hard string cutoff for ALL set strings, common cutoff method, UTF8 aware
 // TODO: Post-demo: Convert all sets to vectors where practical.
@@ -424,7 +423,7 @@ namespace dbtype
          * @param token[in] The lock token.
          * @return True if successfully set.
          */
-        bool set_entity_name(
+        virtual bool set_entity_name(
             const std::string &name,
             concurrency::WriterLockToken &token);
 

--- a/src/dbtypes/dbtype_Exit.cpp
+++ b/src/dbtypes/dbtype_Exit.cpp
@@ -14,7 +14,8 @@
 #include "concurrency/concurrency_LockableObject.h"
 
 #include "logging/log_Logger.h"
-
+#include "utilities/mutgos_config.h"
+#include "text/text_Utf8Tools.h"
 
 namespace mutgos
 {
@@ -88,6 +89,12 @@ namespace dbtype
     {
         bool result = false;
 
+        if (text::utf8_size(message) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
+
         if (token.has_lock(*this))
         {
             exit_arrive_message = message;
@@ -145,6 +152,12 @@ namespace dbtype
         concurrency::WriterLockToken &token)
     {
         bool result = false;
+
+        if (text::utf8_size(message) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
 
         if (token.has_lock(*this))
         {

--- a/src/dbtypes/dbtype_Player.cpp
+++ b/src/dbtypes/dbtype_Player.cpp
@@ -12,6 +12,7 @@
 
 #include "bcrypt/BCrypt.hpp"
 #include "utilities/mutgos_config.h"
+#include "text/text_Utf8Tools.h"
 
 #include "concurrency/concurrency_ReaderLockToken.h"
 #include "concurrency/concurrency_WriterLockToken.h"
@@ -100,11 +101,31 @@ namespace dbtype
     }
 
     // ----------------------------------------------------------------------
+    bool Player::set_entity_name(
+        const std::string &name,
+        mutgos::concurrency::WriterLockToken &token)
+    {
+        if (text::utf8_size(name) > config::db::limits_player_puppet_name())
+        {
+            // Exceeds size.
+            return false;
+        }
+
+        return ContainerPropertyEntity::set_entity_name(name, token);
+    }
+
+    // ----------------------------------------------------------------------
     bool Player::set_password(
         const std::string &new_password,
         concurrency::WriterLockToken &token)
     {
         bool success = false;
+
+        if (text::utf8_size(new_password) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
 
         if (token.has_lock(*this))
         {
@@ -166,6 +187,12 @@ namespace dbtype
         concurrency::WriterLockToken &token)
     {
         bool success = false;
+
+        if (text::utf8_size(name) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
 
         if (token.has_lock(*this))
         {

--- a/src/dbtypes/dbtype_Player.h
+++ b/src/dbtypes/dbtype_Player.h
@@ -70,6 +70,16 @@ namespace dbtype
         virtual std::string to_string(void);
 
         /**
+         * Sets the Player's name.
+         * @param name[in] The name of the Player.
+         * @param token[in] The lock token.
+         * @return True if successfully set.
+         */
+        virtual bool set_entity_name(
+            const std::string &name,
+            concurrency::WriterLockToken &token);
+
+        /**
          * Sets the password.  The password will be encrypted before storing.
          * @param new_password[in] The new, unencrypted password.
          * @param token[in] The lock token.

--- a/src/dbtypes/dbtype_Program.h
+++ b/src/dbtypes/dbtype_Program.h
@@ -107,6 +107,8 @@ namespace dbtype
 
         /**
          * Sets the source code to the provided DocumentProperty.
+         * Suggested to use a Document retrieved by get_source_code(), to
+         * preserve length limits.
          * @param source_code[in] The source code to set.
          * @param token[in] The lock token.
          * @return True if success.
@@ -117,6 +119,8 @@ namespace dbtype
 
         /**
          * Sets the source code to the provided DocumentProperty.
+         * Suggested to use a Document retrieved by get_source_code(), to
+         * preserve length limits.
          * This method automatically gets a lock.
          * @param source_code[in] The source code to set.
          * @return True if success.
@@ -311,6 +315,7 @@ namespace dbtype
         Id get_next_program_include(
             const Id &program_id,
             concurrency::ReaderLockToken &token);
+
         /**
          * This method will automatically get a lock.
          * @param program_id[in] The current position in the program include set.

--- a/src/dbtypes/dbtype_PropertyDirectory.cpp
+++ b/src/dbtypes/dbtype_PropertyDirectory.cpp
@@ -9,15 +9,16 @@
 #include <sstream>
 #include <ostream>
 
+#include <boost/tokenizer.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
 #include "logging/log_Logger.h"
 #include "osinterface/osinterface_OsTypes.h"
+#include "text/text_Utf8Tools.h"
+#include "utilities/mutgos_config.h"
 
 #include "dbtypes/dbtype_PropertyDirectory.h"
 #include "dbtypes/dbtype_PropertyData.h"
-
-
-#include <boost/tokenizer.hpp>
-#include <boost/algorithm/string/trim.hpp>
 
 namespace
 {
@@ -624,6 +625,22 @@ namespace dbtype
         boost::char_separator<char> sep(PATH_SEPARATOR.c_str());
         boost::tokenizer<boost::char_separator<char> >
             tokens(trimmed_path, sep);
+
+        // Check sizes
+        //
+        if (create)
+        {
+            for (boost::tokenizer<boost::char_separator<char> >::iterator
+                     tok_iter = tokens.begin();
+                 tok_iter != tokens.end(); ++tok_iter)
+            {
+                if (text::utf8_size(*tok_iter) > config::db::limits_property_name())
+                {
+                    // Too long. Abort.
+                    return 0;
+                }
+            }
+        }
 
         // Go through the path one segment at a time, traversing the property
         // directories until either the end is found, or a segment cannot

--- a/src/dbtypes/dbtype_PropertyEntity.cpp
+++ b/src/dbtypes/dbtype_PropertyEntity.cpp
@@ -8,6 +8,8 @@
 #include <boost/algorithm/string/trim.hpp>
 
 #include "logging/log_Logger.h"
+#include "text/text_Utf8Tools.h"
+#include "utilities/mutgos_config.h"
 
 #include "dbtypes/dbtype_PropertyEntity.h"
 #include "dbtypes/dbtype_EntityType.h"
@@ -180,6 +182,12 @@ namespace dbtype
         {
             const std::string application =
                 get_application_name_from_path(path);
+
+            if (text::utf8_size(application) > config::db::limits_property_name())
+            {
+                // Application name too long
+                return false;
+            }
 
             if (not application.empty() and
                   (application_properties.find(application) ==

--- a/src/dbtypes/dbtype_Puppet.cpp
+++ b/src/dbtypes/dbtype_Puppet.cpp
@@ -15,6 +15,8 @@
 #include "concurrency/concurrency_WriterLockToken.h"
 #include "concurrency/concurrency_LockableObject.h"
 
+#include "utilities/mutgos_config.h"
+#include "text/text_Utf8Tools.h"
 
 namespace mutgos
 {
@@ -80,11 +82,31 @@ namespace dbtype
     }
 
     // ----------------------------------------------------------------------
+    bool Puppet::set_entity_name(
+        const std::string &name,
+        mutgos::concurrency::WriterLockToken &token)
+    {
+        if (text::utf8_size(name) > config::db::limits_player_puppet_name())
+        {
+            // Exceeds size.
+            return false;
+        }
+
+        return Thing::set_entity_name(name, token);
+    }
+
+    // ----------------------------------------------------------------------
     bool Puppet::set_puppet_display_name(
         const std::string &name,
         concurrency::WriterLockToken &token)
     {
         bool result = false;
+
+        if (text::utf8_size(name) > config::db::limits_string_size())
+        {
+            // Exceeds size.
+            return false;
+        }
 
         if (token.has_lock(*this))
         {

--- a/src/dbtypes/dbtype_Puppet.h
+++ b/src/dbtypes/dbtype_Puppet.h
@@ -75,6 +75,16 @@ namespace dbtype
         virtual std::string to_string(void);
 
         /**
+         * Sets the Puppet's name.
+         * @param name[in] The name of the Puppet.
+         * @param token[in] The lock token.
+         * @return True if successfully set.
+         */
+        virtual bool set_entity_name(
+            const std::string &name,
+            concurrency::WriterLockToken &token);
+
+        /**
          * Sets the puppet display name.
          * @param name[in] The puppet display name.
          * @param token[in] The lock token.

--- a/src/dbtypes/dbtype_SetProperty.cpp
+++ b/src/dbtypes/dbtype_SetProperty.cpp
@@ -16,10 +16,10 @@
 
 #include "dbtypes/dbtype_SetProperty.h"
 #include "osinterface/osinterface_OsTypes.h"
+#include "utilities/mutgos_config.h"
 
 namespace
 {
-    const MG_UnsignedInt MAX_SET_SIZE = 1024;
     const MG_UnsignedInt SHORT_STRING_SIZE = 60;
     const MG_UnsignedInt MAX_STRING_SIZE = 32768; // for get_as_string()
 }
@@ -420,7 +420,7 @@ namespace dbtype
     // ----------------------------------------------------------------------
     bool SetProperty::is_full(void) const
     {
-        return property_data_set.size() > MAX_SET_SIZE;
+        return property_data_set.size() > config::db::limits_property_set_items();
     }
 
     // ----------------------------------------------------------------------

--- a/src/dbtypes/dbtype_StringProperty.cpp
+++ b/src/dbtypes/dbtype_StringProperty.cpp
@@ -6,9 +6,10 @@
 #include <stddef.h>
 
 #include "dbtypes/dbtype_StringProperty.h"
+#include "utilities/mutgos_config.h"
+#include "text/text_Utf8Tools.h"
 
 #define SHORT_STRING_LENGTH 60
-#define MAX_STRING_LENGTH 1024
 
 namespace mutgos
 {
@@ -18,13 +19,6 @@ namespace mutgos
         StringProperty::StringProperty()
           : PropertyData(PROPERTYDATATYPE_string)
         {
-        }
-
-        // ------------------------------------------------------------------
-        StringProperty::StringProperty(const std::string &data)
-          : PropertyData(PROPERTYDATATYPE_string)
-        {
-            string_data = data.substr(0, MAX_STRING_LENGTH);
         }
 
         // ------------------------------------------------------------------
@@ -118,7 +112,12 @@ namespace mutgos
         // ------------------------------------------------------------------
         bool StringProperty::set(const std::string &str)
         {
-            string_data = str.substr(0, MAX_STRING_LENGTH);
+            if (text::utf8_size(str) > config::db::limits_string_size())
+            {
+                return false;
+            }
+
+            string_data = str;
 
             return true;
         }

--- a/src/dbtypes/dbtype_StringProperty.h
+++ b/src/dbtypes/dbtype_StringProperty.h
@@ -32,12 +32,6 @@ namespace dbtype
         StringProperty();
 
         /**
-         * Creates with a provided string.
-         * @param data[in] The string data.
-         */
-        StringProperty(const std::string &data);
-
-        /**
          * Copy constructor.
          * @param rhs The source to copy from.
          */

--- a/src/exe/read_dump/read_dump.cpp
+++ b/src/exe/read_dump/read_dump.cpp
@@ -14,7 +14,7 @@
 #define HELP_ARG "help"
 #define CONFIGFILE_ARG "configfile"
 #define DUMPFILE_ARG "dumpfile"
-#define DATAFILE_ARG "datafile"
+#define DATAPATH_ARG "datapath"
 
 // TODO Update documentation for how to run.
 
@@ -102,15 +102,15 @@ int main(int argc, char* argv[])
            (DUMPFILE_ARG,
                boost::program_options::value<std::string>(),
                "The dump file to read in.  Default is mutgos.dump")
-           (DATAFILE_ARG,
+           (DATAPATH_ARG,
                boost::program_options::value<std::string>(),
-               "Specifies the path and filename to save the generated database to.  Default is mutgos.db")
+               "Specifies the path to save the generated database.  File name is specified in the config file.  Default is what's in the config file.")
         ;
 
     boost::program_options::variables_map args;
     std::string config_file = "mutgos.conf";
     std::string dump_file = "mutgos.dump";
-    std::string data_file = "mutgos.db";
+    std::string data_path = "";
     const bool good_parse = parse_commandline(option_desc, args, argc, argv);
 
     if (not good_parse)
@@ -135,13 +135,13 @@ int main(int argc, char* argv[])
         dump_file = args[DUMPFILE_ARG].as<std::string>();
     }
 
-    if (args.count(DATAFILE_ARG))
+    if (args.count(DATAPATH_ARG))
     {
-        data_file = args[DATAFILE_ARG].as<std::string>();
+        data_path = args[DATAPATH_ARG].as<std::string>();
     }
 
     mutgos::log::Logger::init(true);
-    const bool good_config_read = mutgos::config::parse_config(config_file, "");
+    const bool good_config_read = mutgos::config::parse_config(config_file, data_path);
 
     if (not good_config_read)
     {

--- a/src/exe/read_dump/read_dump.cpp
+++ b/src/exe/read_dump/read_dump.cpp
@@ -5,21 +5,150 @@
 #include <string>
 #include <iostream>
 #include "text/text_StringConversion.h"
+#include <boost/program_options.hpp>
 
 #include "logging/log_Logger.h"
 #include "dbdump/dbdump_MutgosDumpFileReader.h"
+#include "utilities/mutgos_config.h"
+
+#define HELP_ARG "help"
+#define CONFIGFILE_ARG "configfile"
+#define DUMPFILE_ARG "dumpfile"
+#define DATAFILE_ARG "datafile"
+
+// TODO Update documentation for how to run.
+
+/**
+ * Parses the commandline.
+ * @param options[in] The arguments allowed.
+ * @param args[out] The parsed arguments.
+ * @param argc[in] Argument count from the raw commandline.
+ * @param argv[in] The raw arguments from the raw commandline.
+ * @return True if successfully parsed.
+ */
+bool parse_commandline(
+    boost::program_options::options_description &options,
+    boost::program_options::variables_map &args,
+    int argc,
+    char *argv[])
+{
+    bool success = true;
+
+    try
+    {
+        boost::program_options::store(
+            boost::program_options::parse_command_line(argc, argv, options),
+            args);
+        boost::program_options::notify(args);
+    }
+    catch (boost::program_options::unknown_option &uoex)
+    {
+        success = false;
+
+        std::cout << "ERROR: "
+                  << "Unknown argument: " << uoex.get_option_name() << std::endl;
+    }
+    catch (boost::program_options::validation_error &vex)
+    {
+        success = false;
+
+        std::cout << "ERROR: "
+                  << "Bad value for argument: " << vex.get_option_name()
+                  << std::endl;
+    }
+    catch (boost::program_options::multiple_occurrences &moex)
+    {
+        success = false;
+
+        std::cout << "ERROR: "
+                  << "More than one instance of argument: "
+                  << moex.get_option_name() << std::endl;
+    }
+    catch (boost::program_options::multiple_values &mvex)
+    {
+        success = false;
+
+        std::cout << "ERROR: "
+                  << "More than one value of argument: "
+                  << mvex.get_option_name() << std::endl;
+    }
+    catch (boost::program_options::error &eex)
+    {
+        success = false;
+
+        std::cout << "ERROR: "
+                  << "Error parsing arguments: "  << eex.what() << std::endl;
+    }
+
+    return success;
+}
 
 int main(int argc, char* argv[])
 {
-    if (argc != 2)
+    int rc = 0;
+
+    std::cout << "Read Dump Utility.  Use --help for usage information."
+              << std::endl
+              << std::endl;
+
+    boost::program_options::options_description
+        option_desc("Read Dump Utility Options");
+
+    option_desc.add_options()
+           (HELP_ARG, "Show this help screen")
+           (CONFIGFILE_ARG,
+               boost::program_options::value<std::string>(),
+               "The config file to load and use.  Default is mutgos.conf")
+           (DUMPFILE_ARG,
+               boost::program_options::value<std::string>(),
+               "The dump file to read in.  Default is mutgos.dump")
+           (DATAFILE_ARG,
+               boost::program_options::value<std::string>(),
+               "Specifies the path and filename to save the generated database to.  Default is mutgos.db")
+        ;
+
+    boost::program_options::variables_map args;
+    std::string config_file = "mutgos.conf";
+    std::string dump_file = "mutgos.dump";
+    std::string data_file = "mutgos.db";
+    const bool good_parse = parse_commandline(option_desc, args, argc, argv);
+
+    if (not good_parse)
     {
-        std::cerr << "Syntax is: " << argv[0] << " <dump_file>" << std::endl;
+        // Error message already printed.
         return -1;
     }
 
-    mutgos::log::Logger::init(true);
+    if (args.count(HELP_ARG))
+    {
+        std::cout << option_desc << std::endl;
+        return 0;
+    }
 
-    const std::string dump_file = argv[1];
+    if (args.count(CONFIGFILE_ARG))
+    {
+        config_file = args[CONFIGFILE_ARG].as<std::string>();
+    }
+
+    if (args.count(DUMPFILE_ARG))
+    {
+        dump_file = args[DUMPFILE_ARG].as<std::string>();
+    }
+
+    if (args.count(DATAFILE_ARG))
+    {
+        data_file = args[DATAFILE_ARG].as<std::string>();
+    }
+
+    mutgos::log::Logger::init(true);
+    const bool good_config_read = mutgos::config::parse_config(config_file, "");
+
+    if (not good_config_read)
+    {
+        std::cout << "ERROR: Failed to parse config file." << std::endl;
+        return -1;
+    }
+
     std::string message;
     mutgos::dbdump::MutgosDumpFileReader reader(dump_file);
 
@@ -34,7 +163,9 @@ int main(int argc, char* argv[])
                   << "  Line: " << mutgos::text::to_string(
                      reader.get_current_line_index()) << std::endl
                   << "  Message: " << message << std::endl;
+
+        rc = -1;
     }
 
-    return 0;
+    return rc;
 }

--- a/src/primitives/primitives_DatabasePrims.cpp
+++ b/src/primitives/primitives_DatabasePrims.cpp
@@ -1835,14 +1835,22 @@ namespace primitives
         const std::string &property_value,
         const bool throw_on_violation)
     {
-        const dbtype::StringProperty property_obj =
-            dbtype::StringProperty(property_value);
-        Result result = set_property_raw(
-            context,
-            entity_id,
-            property_path,
-            &property_obj,
-            throw_on_violation);
+        Result result;
+        dbtype::StringProperty property_obj;
+
+        if (not property_obj.set(property_value))
+        {
+            result.set_status(Result::STATUS_BAD_ARGUMENTS);
+        }
+        else
+        {
+            result = set_property_raw(
+                context,
+                entity_id,
+                property_path,
+                &property_obj,
+                throw_on_violation);
+        }
 
         return result;
     }

--- a/src/primitives/primitives_SystemPrims.cpp
+++ b/src/primitives/primitives_SystemPrims.cpp
@@ -28,10 +28,7 @@
 
 #include "comminterface/comm_CommAccess.h"
 
-namespace
-{
-    #define TELNET_LF '\n'
-}
+#define TELNET_LF '\n'
 
 namespace mutgos
 {
@@ -171,6 +168,7 @@ namespace primitives
     }
 
     // ----------------------------------------------------------------------
+    // TODO Remove once temporary commands gone.  This is not supposed to be used long term.
     Result SystemPrims::to_external_text_multiline_unformatted(
         security::Context &context,
         const std::string &text,
@@ -390,3 +388,5 @@ namespace primitives
     }
 }
 }
+
+#undef TELNET_LF

--- a/src/text/text_Utf8Tools.cpp
+++ b/src/text/text_Utf8Tools.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <string>
+#include <cstring>
 
 #include "text_Utf8Tools.h"
 
@@ -378,6 +379,724 @@ namespace text
         }
 
         return result;
+    }
+
+    // ----------------------------------------------------------------------
+    bool utf8_valid(const std::string &str)
+    {
+        return utf8_valid(str.c_str(), str.size());
+    }
+
+    // ----------------------------------------------------------------------
+    bool utf8_valid(const char *str, const size_t len)
+    {
+        bool valid = true;
+
+        // Null and empty checks.
+        //
+        if (not str)
+        {
+            return false;
+        }
+        else if (not len)
+        {
+            return true;
+        }
+
+        size_t index = 0;
+        unsigned short utf8_bytes_left = 0;
+
+        while (index < len)
+        {
+            const unsigned char current_char = (unsigned char) str[index];
+
+            if (utf8_bytes_left)
+            {
+                // In the middle of UTF8.  See if this is a 'continue' byte.
+                //
+                if ((current_char & UTF8_CONTINUE_SEARCH_MASK) ==
+                    UTF8_CONTINUE)
+                {
+                    --utf8_bytes_left;
+                }
+                else
+                {
+                    // Not a valid continue.  Invalid UTF8
+                    break;
+                }
+            }
+            else if (current_char < PRINTABLE_ASCII_BEGIN)
+            {
+                // Not printable; invalid.
+                valid = false;
+                break;
+            }
+            else if (current_char > PRINTABLE_ASCII_END)
+            {
+                // Not normal ASCII, so check for UTF8.
+                //
+                if ((current_char & TWO_BYTE_UTF8_START_SEARCH_MASK) ==
+                    TWO_BYTE_UTF8_START)
+                {
+                    // Potentially valid 2 byte character.  Check it.
+                    utf8_bytes_left = 1;
+                }
+                else if ((current_char & THREE_BYTE_UTF8_START_SEARCH_MASK) ==
+                         THREE_BYTE_UTF8_START)
+                {
+                    // Potentially valid 3 byte character.  Check it.
+                    utf8_bytes_left = 2;
+                }
+                else if ((current_char & FOUR_BYTE_UTF8_START_SEARCH_MASK) ==
+                         FOUR_BYTE_UTF8_START)
+                {
+                    // Potentially valid 4 byte character.  Check it.
+                    utf8_bytes_left = 3;
+                }
+                else
+                {
+                    // Unknown what this is.  Invalid.
+                    valid = false;
+                    break;
+                }
+            }
+
+            ++index;
+        }
+
+        if (utf8_bytes_left)
+        {
+            // We ended in the middle of UTF8.  Always invalid.
+            valid = false;
+        }
+
+        return valid;
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_size(const std::string &str)
+    {
+        return utf8_size(str.c_str(), str.size());
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_size(const char *str, const size_t len)
+    {
+        size_t size = 0;
+
+        // Null and empty checks.
+        //
+        if ((not str) or (not len))
+        {
+            return size;
+        }
+
+        size_t index = 0;
+        unsigned short utf8_bytes_left = 0;
+
+        while (index < len)
+        {
+            const unsigned char current_char = (unsigned char) str[index];
+
+            if (utf8_bytes_left)
+            {
+                // In the middle of UTF8.  See if this is a 'continue' byte.
+                // The entry to the code point already counts as the
+                // element for size.
+                //
+                if ((current_char & UTF8_CONTINUE_SEARCH_MASK) ==
+                    UTF8_CONTINUE)
+                {
+                    --utf8_bytes_left;
+                }
+                else
+                {
+                    // Not a valid continue.  Invalid UTF8
+                    size = 0;
+                    break;
+                }
+            }
+            else if (current_char < PRINTABLE_ASCII_BEGIN)
+            {
+                // Not printable; invalid.
+                size = 0;
+                break;
+            }
+            else if (current_char > PRINTABLE_ASCII_END)
+            {
+                // Not normal ASCII, so check for UTF8.
+                //
+                if ((current_char & TWO_BYTE_UTF8_START_SEARCH_MASK) ==
+                    TWO_BYTE_UTF8_START)
+                {
+                    // Potentially valid 2 byte character.  Check it.
+                    utf8_bytes_left = 1;
+                    ++size;
+                }
+                else if ((current_char & THREE_BYTE_UTF8_START_SEARCH_MASK) ==
+                         THREE_BYTE_UTF8_START)
+                {
+                    // Potentially valid 3 byte character.  Check it.
+                    utf8_bytes_left = 2;
+                    ++size;
+                }
+                else if ((current_char & FOUR_BYTE_UTF8_START_SEARCH_MASK) ==
+                         FOUR_BYTE_UTF8_START)
+                {
+                    // Potentially valid 4 byte character.  Check it.
+                    utf8_bytes_left = 3;
+                    ++size;
+                }
+                else
+                {
+                    // Unknown what this is.  Invalid.
+                    size = 0;
+                    break;
+                }
+            }
+            else
+            {
+                // Valid, normal ASCII.  Counts as one element.
+                ++size;
+            }
+
+            ++index;
+        }
+
+        if (utf8_bytes_left)
+        {
+            // We ended in the middle of UTF8.  Always invalid.
+            size = 0;
+        }
+
+        return size;
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_index_to_byte(const std::string &str, const size_t utf8_index)
+    {
+        return utf8_index_to_byte(str.c_str(), str.size(), utf8_index);
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_index_to_byte(
+        const char *str,
+        const size_t len,
+        const size_t utf8_index)
+    {
+        size_t byte = 0;
+
+        if ((not str) or (not len))
+        {
+            return byte;
+        }
+
+        if (not utf8_index)
+        {
+            return byte;
+        }
+
+        size_t current_index = 0;
+
+        while ((byte < len) and (current_index < utf8_index))
+        {
+            const unsigned char current_char = (unsigned char) str[byte];
+
+            if (current_char > PRINTABLE_ASCII_END)
+            {
+                // Not normal ASCII, so check for UTF8.
+                //
+                if ((current_char & TWO_BYTE_UTF8_START_SEARCH_MASK) ==
+                    TWO_BYTE_UTF8_START)
+                {
+                    // 2 byte character.  Skip over.
+                    byte += 2;
+                }
+                else if ((current_char & THREE_BYTE_UTF8_START_SEARCH_MASK) ==
+                         THREE_BYTE_UTF8_START)
+                {
+                    // 3 byte character. Skip over.
+                    byte += 3;
+                }
+                else if ((current_char & FOUR_BYTE_UTF8_START_SEARCH_MASK) ==
+                         FOUR_BYTE_UTF8_START)
+                {
+                    // 4 byte character.  Skip over.
+                    byte += 4;
+                }
+                else
+                {
+                    // Unknown what this is.  Invalid.
+                    byte = 0;
+                    break;
+                }
+            }
+            else
+            {
+                // Valid, normal ASCII.  Counts as one element.
+                ++byte;
+            }
+
+            ++current_index;
+        }
+
+        if (current_index != utf8_index)
+        {
+            // Internal, unexpected error occurred.
+            byte = 0;
+        }
+
+        return byte;
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_byte_to_index(const std::string &str, const size_t byte)
+    {
+        return utf8_byte_to_index(str.c_str(), str.size(), byte);
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_byte_to_index(
+        const char *str,
+        const size_t len,
+        const size_t byte)
+    {
+        size_t utf8_index = 0;
+
+        if ((not str) or (not len))
+        {
+            return byte;
+        }
+
+        if (not byte)
+        {
+            return byte;
+        }
+
+        size_t current_byte = 0;
+
+        while ((current_byte < len) && (current_byte < byte))
+        {
+            const unsigned char current_char =
+                (unsigned char) str[current_byte];
+
+            if (current_char > PRINTABLE_ASCII_END)
+            {
+                // Not normal ASCII, so check for UTF8.
+                //
+                if ((current_char & TWO_BYTE_UTF8_START_SEARCH_MASK) ==
+                    TWO_BYTE_UTF8_START)
+                {
+                    // 2 byte character.  Skip over.
+                    current_byte += 2;
+                }
+                else if ((current_char & THREE_BYTE_UTF8_START_SEARCH_MASK) ==
+                         THREE_BYTE_UTF8_START)
+                {
+                    // 3 byte character. Skip over.
+                    current_byte += 3;
+                }
+                else if ((current_char & FOUR_BYTE_UTF8_START_SEARCH_MASK) ==
+                         FOUR_BYTE_UTF8_START)
+                {
+                    // 4 byte character.  Skip over.
+                    current_byte += 4;
+                }
+                else
+                {
+                    // Unknown what this is.  Invalid.
+                    utf8_index = 0;
+                    break;
+                }
+            }
+            else
+            {
+                // Valid, normal ASCII.  Counts as one element.
+                ++current_byte;
+            }
+
+            ++utf8_index;
+        }
+
+        if (current_byte < byte)
+        {
+            // Internal, unexpected error occurred.
+            utf8_index = 0;
+        }
+        else if (current_byte > byte)
+        {
+            // We overshot and are still within the previous code point.
+            --utf8_index;
+        }
+
+        return utf8_index;
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_find(
+        const std::string &str,
+        const std::string &to_find,
+        const size_t start)
+    {
+        return utf8_find(
+            str.c_str(),
+            str.size(),
+            to_find.c_str(),
+            to_find.size(),
+            start);
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_find(
+        const char *str,
+        const size_t len,
+        const char *to_find,
+        const size_t to_find_len,
+        const size_t start)
+    {
+        size_t found_index = std::string::npos;
+
+        if ((not str) or (not to_find) or (not len) or (not to_find_len) or
+            (to_find_len > len))
+        {
+            // Strings are empty, null, or the string to find is bigger than
+            // the string to search.
+            return found_index;
+        }
+
+        // First find the starting byte
+        const size_t start_byte_index = utf8_index_to_byte(str, len, start);
+
+        if (start and (not start_byte_index))
+        {
+            // Error returned while looking for starting byte (beyond end?), so
+            // return error.
+            return found_index;
+        }
+
+        // Do the find.
+        //
+        size_t found_byte_index = std::string::npos;
+        size_t current_byte_index = start_byte_index;
+
+        while (current_byte_index <= (len - to_find_len))
+        {
+            const void * const found_byte_ptr = memchr(
+                &str[current_byte_index],
+                to_find[0],
+                len - current_byte_index);
+
+            if (found_byte_ptr == NULL)
+            {
+                // No chance of substring being here.  Exit now.
+                break;
+            }
+            else
+            {
+                // Convert pointer to byte offset
+                //
+                current_byte_index = ((const char *) found_byte_ptr) - str;
+
+                if (to_find_len == 1)
+                {
+                    // Single character search, so we've found the match.
+                    found_byte_index = current_byte_index;
+                    break;
+                }
+                else
+                {
+                    // Chance of finding substring.  Search for it.
+                    //
+                    if (memcmp(
+                        &str[current_byte_index + 1],
+                        &to_find[1],
+                        to_find_len - 1) == 0)
+                    {
+                        // Found substring!
+                        found_byte_index = current_byte_index;
+                        break;
+                    }
+                    else
+                    {
+                        // Did not find it, so advance one and try again.
+                        ++current_byte_index;
+                    }
+                }
+            }
+        }
+
+        if (found_byte_index != std::string::npos)
+        {
+            // Convert back to UTF8 index and return
+            found_index = utf8_byte_to_index(str, len, found_byte_index);
+        }
+
+        return found_index;
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_find_last(
+        const std::string &str,
+        const std::string &to_find)
+    {
+        return utf8_find_last(str.c_str(), str.size(), to_find.c_str(),
+            to_find.size());
+    }
+
+    // ----------------------------------------------------------------------
+    size_t utf8_find_last(
+        const char *str,
+        const size_t len,
+        const char *to_find,
+        const size_t to_find_len)
+    {
+        size_t found_index = std::string::npos;
+        const static size_t MAX_INDEX = static_cast<size_t>(-1);
+
+        if ((not str) or (not to_find) or (not len) or (not to_find_len) or
+            (to_find_len > len))
+        {
+            // Strings are empty, null, or the string to find is bigger than
+            // the string to search.
+            return found_index;
+        }
+
+        // Do the find.
+        //
+        size_t found_byte_index = std::string::npos;
+        size_t current_byte_index = len - to_find_len;
+
+        while (current_byte_index != MAX_INDEX)
+        {
+            const void * const found_byte_ptr = memrchr(
+                str,
+                to_find[0],
+                current_byte_index);
+
+            if (found_byte_ptr == NULL)
+            {
+                // No chance of substring being here.  Exit now.
+                break;
+            }
+            else
+            {
+                // Convert pointer to byte offset
+                //
+                current_byte_index = ((const char *) found_byte_ptr) - str;
+
+                if (to_find_len == 1)
+                {
+                    // Single character search, so we've found the match.
+                    found_byte_index = current_byte_index;
+                    break;
+                }
+                else
+                {
+                    // Chance of finding substring.  Search for it.
+                    //
+                    if (memcmp(
+                        &str[current_byte_index + 1],
+                        &to_find[1],
+                        to_find_len - 1) == 0)
+                    {
+                        // Found substring!
+                        found_byte_index = current_byte_index;
+                        break;
+                    }
+                    else
+                    {
+                        // Did not find it, so go back one and try again.
+                        --current_byte_index;
+                    }
+                }
+            }
+        }
+
+        if (found_byte_index != std::string::npos)
+        {
+            // Convert back to UTF8 index and return
+            found_index = utf8_byte_to_index(str, len, found_byte_index);
+        }
+
+        return found_index;
+    }
+
+    // ----------------------------------------------------------------------
+    std::string utf8_char_at(const std::string &str, const size_t utf8_index)
+    {
+        return utf8_char_at(str.c_str(), str.size(), utf8_index);
+    }
+
+    // ----------------------------------------------------------------------
+    std::string utf8_char_at(
+        const char *str,
+        const size_t len,
+        const size_t utf8_index)
+    {
+        std::string found_char;
+
+        if ((not str) or (not len))
+        {
+            return found_char;
+        }
+
+        const size_t byte_index = utf8_index_to_byte(str, len, utf8_index);
+
+        if (utf8_index and (not byte_index))
+        {
+            // Error returned while looking for index (beyond end?), so
+            // return error.
+            return found_char;
+        }
+
+        // Determine if this is a UTF8 character, and if so extract all bytes.
+        //
+        const unsigned char current_char =
+            (unsigned char) str[byte_index];
+
+        if (current_char > PRINTABLE_ASCII_END)
+        {
+            // Not normal ASCII, so check for UTF8.
+            //
+            if ((current_char & TWO_BYTE_UTF8_START_SEARCH_MASK) ==
+                TWO_BYTE_UTF8_START)
+            {
+                // 2 byte character.
+                found_char.assign(&str[byte_index], 2);
+            }
+            else if ((current_char & THREE_BYTE_UTF8_START_SEARCH_MASK) ==
+                     THREE_BYTE_UTF8_START)
+            {
+                // 3 byte character.
+                found_char.assign(&str[byte_index], 3);
+            }
+            else if ((current_char & FOUR_BYTE_UTF8_START_SEARCH_MASK) ==
+                     FOUR_BYTE_UTF8_START)
+            {
+                // 4 byte character.
+                found_char.assign(&str[byte_index], 4);
+            }
+        }
+        else
+        {
+            // Valid, normal ASCII. Just extract the one character.
+            found_char.assign(1, current_char);
+        }
+
+        return found_char;
+    }
+
+    // ----------------------------------------------------------------------
+    std::string utf8_chop_at_limit(
+        const std::string &str,
+        const size_t utf8_size)
+    {
+        return utf8_chop_at_limit(str.c_str(), str.size(), utf8_size);
+    }
+
+    // ----------------------------------------------------------------------
+    std::string utf8_chop_at_limit(
+        const char *str,
+        const size_t len,
+        const size_t utf8_size)
+    {
+        std::string result;
+
+        if ((not str) or (not len) or (not utf8_size))
+        {
+            return result;
+        }
+
+        const size_t byte_index = utf8_index_to_byte(str, len, utf8_size);
+
+        if (utf8_size and (not byte_index))
+        {
+            // Likely utf8_size is bigger than string, so return everything.
+            result.assign(str, len);
+        }
+        else
+        {
+            // Not past the limit, so use up to the index.
+            result.assign(str, byte_index);
+        }
+
+        return result;
+    }
+
+    // ----------------------------------------------------------------------
+    void utf8_chop_modify_at_limit(
+        std::string &str,
+        const size_t utf8_size)
+    {
+        if (not utf8_size)
+        {
+            str.clear();
+            str.shrink_to_fit();
+        }
+
+        const size_t byte_index = utf8_index_to_byte(str, utf8_size);
+
+        if (not (utf8_size and (not byte_index)))
+        {
+            // Chop off end of string since it's too long.
+            str.erase(byte_index);
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    void utf8_split(
+        const std::string &str,
+        const size_t utf8_index,
+        std::string &before_str,
+        std::string &after_str)
+    {
+        utf8_split(str.c_str(), str.size(), utf8_index, before_str, after_str);
+    }
+
+    // ----------------------------------------------------------------------
+    void utf8_split(
+        const char *str,
+        const size_t len,
+        const size_t utf8_index,
+        std::string &before_str,
+        std::string &after_str)
+    {
+        if ((not str) or (not len))
+        {
+            // Invalid string.  Return nothing.
+            //
+            before_str.clear();
+            before_str.shrink_to_fit();
+            after_str.clear();
+            after_str.shrink_to_fit();
+            return;
+        }
+
+        if (not utf8_index)
+        {
+            // Easy case where everything goes to 'after'.
+            before_str.clear();
+            before_str.shrink_to_fit();
+            after_str.assign(str, len);
+        }
+        else
+        {
+            const size_t byte_index = utf8_index_to_byte(str, len, utf8_index);
+
+            if (not byte_index)
+            {
+                // Likely utf8_index is bigger than string, so return everything
+                // in 'before'.
+                before_str.assign(str, len);
+                after_str.clear();
+                after_str.shrink_to_fit();
+            }
+            else
+            {
+                before_str.assign(str, byte_index);
+                after_str.assign(&str[byte_index], len - byte_index);
+            }
+        }
     }
 }
 }

--- a/src/text/text_Utf8Tools.h
+++ b/src/text/text_Utf8Tools.h
@@ -49,6 +49,255 @@ namespace text
     unsigned char convert_bits_to_extended(
         const unsigned char first,
         const unsigned char second);
+
+    /**
+     * @param str[in] The string to check.
+     * @return True if string is valid utf8 and completely printable,
+     * false if not.  Unprintable non-UTF8 codes are considered invalid.
+     */
+    bool utf8_valid(const std::string &str);
+
+    /**
+     * @param str[in] The string to check.
+     * @param len[in] The length of the string.
+     * @return True if string is valid utf8 and completely printable,
+     * false if not.  Unprintable non-UTF8 codes are considered invalid.
+     */
+    bool utf8_valid(const char *str, const size_t len);
+
+    /**
+     * Determines the 'UTF8 size' of a string.  Normally each byte
+     * in a string is considered an element.  The size is therefore the
+     * number of bytes.  In order to standardize how UTF8 strings
+     * are manipulated, the 'UTF8 size' considers a code point to be
+     * one 'element'.  Example: A string with one ascii character and
+     * a 4 byte UTF8 character has a size of 2.  Methods below aid in
+     * converting byte position to an index relative to 'UTF8 size'.
+     * @param str[in] The string to get the UTF8 size of.
+     * @return The UTF8 size of the string, or 0 if
+     * error or not valid UTF8.
+     */
+    size_t utf8_size(const std::string &str);
+
+    /**
+     * @param str[in] The string to get the UTF8 size of.
+     * @param len[in] The length of str.
+     * @return The UTF8 size of the string, or 0 if
+     * error or not valid UTF8.
+     * @see utf8_size(const std::string &str) for explanation of
+     * 'UTF8 size' and indexing.
+     */
+    size_t utf8_size(const char *str, const size_t len);
+
+    /**
+     * Converts a 'UTF8 index' to the actual byte index in the string.
+     * This is useful for making substrings, searching, etc.
+     * @param str[in] The string to get the byte index for.
+     * @param utf8_index[in] The UTF8 index to look up the byte index for.
+     * @return The byte index in str that corresponds to utf8_index.  If
+     * an error occurs (out of bounds, etc), 0 is returned.
+     * @see utf8_size(const std::string &str) for explanation of
+     * 'UTF8 size' and indexing.
+     */
+    size_t utf8_index_to_byte(const std::string &str, const size_t utf8_index);
+
+    /**
+     * Converts a 'UTF8 index' to the actual byte index in the string.
+     * This is useful for making substrings, searching, etc.
+     * @param str[in] The string to get the byte index for.
+     * @param len[in] The length of the string.
+     * @param utf8_index[in] The UTF8 index to look up the byte index for.
+     * @return The byte index in str that corresponds to utf8_index.  If
+     * an error occurs (out of bounds, etc), 0 is returned.
+     * @see utf8_size(const std::string &str) for explanation of
+     * 'UTF8 size' and indexing.
+     */
+    size_t utf8_index_to_byte(
+        const char *str,
+        const size_t len,
+        const size_t utf8_index);
+
+    /**
+     * Converts a byte index in a string to the 'UTF8 index'.
+     * @param str[in] The string to get the UTF8 index for.
+     * @param byte[in] The byte index to look up the UTF8 index for.
+     * @return The UTF8 index, or 0 if error.
+     * @see utf8_size(const std::string &str) for explanation of
+     * 'UTF8 size' and indexing.
+     */
+    size_t utf8_byte_to_index(const std::string &str, const size_t byte);
+
+    /**
+     * Converts a byte index in a string to the 'UTF8 index'.
+     * @param str[in] The string to get the UTF8 index for.
+     * @param len[in] The length of str.
+     * @param byte[in] The byte index to look up the UTF8 index for.
+     * @return The UTF8 index, or 0 if error.
+     * @see utf8_size(const std::string &str) for explanation of
+     * 'UTF8 size' and indexing.
+     */
+    size_t utf8_byte_to_index(
+        const char *str,
+        const size_t len,
+        const size_t byte);
+
+    /**
+     * Finds a UTF8 string inside of a larger UTF8 string.
+     * @param str[in] The string to search inside.  Must be valid UTF8.
+     * @param to_find[in] The substring to find inside of str.
+     * Must be valid UTF8.
+     * @param start[in] The UTF8 index to start searching at.
+     * @return The UTF8 index of the found substring, or std::string::npos
+     * if not found.
+     * @see utf8_size() for explanation on 'UTF8 index'.
+     */
+    size_t utf8_find(
+        const std::string &str,
+        const std::string &to_find,
+        const size_t start = 0);
+
+    /**
+     * Finds a UTF8 string inside of a larger UTF8 string.
+     * @param str[in] The string to search inside.  Must be valid UTF8.
+     * @param len[in] The length of str.
+     * @param to_find[in] The substring to find inside of str.
+     * Must be valid UTF8.
+     * @param to_find_len[in] The length of to_find.
+     * @param start[in] The UTF8 index to start searching at.
+     * @return The UTF8 index of the found substring, or std::string::npos
+     * if not found.
+     * @see utf8_size() for explanation on 'UTF8 index'.
+     */
+    size_t utf8_find(
+        const char *str,
+        const size_t len,
+        const char *to_find,
+        const size_t to_find_len,
+        const size_t start = 0);
+
+    /**
+     * Finds the last occurance of a UTF8 string inside of a larger UTF8 string.
+     * @param str[in] The string to search inside.  Must be valid UTF8.
+     * @param to_find[in] The substring to find inside of str.
+     * Must be valid UTF8.
+     * @return The UTF8 index of the last found substring, or std::string::npos
+     * if not found.
+     * @see utf8_size() for explanation on 'UTF8 index'.
+     */
+    size_t utf8_find_last(
+        const std::string &str,
+        const std::string &to_find);
+
+    /**
+     * Finds the last occurance of a UTF8 string inside of a larger UTF8 string.
+     * @param str[in] The string to search inside.  Must be valid UTF8.
+     * @param len[in] The length of str.
+     * @param to_find[in] The substring to find inside of str.
+     * Must be valid UTF8.
+     * @param to_find_len[in] The length of to_find.
+     * @return The UTF8 index of the last found substring, or std::string::npos
+     * if not found.
+     * @see utf8_size() for explanation on 'UTF8 index'.
+     */
+    size_t utf8_find_last(
+        const char *str,
+        const size_t len,
+        const char *to_find,
+        const size_t to_find_len);
+
+    /**
+     * Gets the character at the given UTF8 index.  If this is a UTF8
+     * character, multiple bytes will be returned.  Must be valid UTF8.
+     * @param str[in] The string to get the character from.  Must be valid UTF8.
+     * @param utf8_index[in] The UTF8 index of the character to retrieve.
+     * @return The character at the UTF8 index, or empty if error
+     * (out of bounds, etc).
+     * @see utf8_size() for explanation on 'UTF8 index'.
+     */
+    std::string utf8_char_at(const std::string &str, const size_t utf8_index);
+
+    /**
+     * Gets the character at the given UTF8 index.  If this is a UTF8
+     * character, multiple bytes will be returned.  Must be valid UTF8.
+     * @param str[in] The string to get the character from.  Must be valid UTF8.
+     * @param len[in] The length of str.
+     * @param utf8_index[in] The UTF8 index of the character to retrieve.
+     * @return The character at the UTF8 index, or empty if error
+     * (out of bounds, etc).
+     * @see utf8_size() for explanation on 'UTF8 index'.
+     */
+    std::string utf8_char_at(
+        const char *str,
+        const size_t len,
+        const size_t utf8_index);
+
+    /**
+     * Used to ensure a string is no bigger than a given number of UTF8
+     * characters.  Must be valid UTF8.
+     * @param str[in] The string to limit.
+     * @param utf8_size[in] How many UTF8 characters to allow.
+     * @return str with no more than utf8_size UTF8 characters.
+     * @see utf8_size() for explanation on 'UTF8 index' / size
+     */
+    std::string utf8_chop_at_limit(
+        const std::string &str,
+        const size_t utf8_size);
+
+    /**
+     * Used to ensure a string is no bigger than a given number of UTF8
+     * characters.  Must be valid UTF8.
+     * @param str[in] The string to limit.
+     * @param len[in] The length of str.
+     * @param utf8_size[in] How many UTF8 characters to allow.
+     * @return str with no more than utf8_size UTF8 characters.
+     * @see utf8_size() for explanation on 'UTF8 index' / size
+     */
+    std::string utf8_chop_at_limit(
+        const char *str,
+        const size_t len,
+        const size_t utf8_size);
+
+    /**
+     * Used to ensure a string is no bigger than a given number of UTF8
+     * characters.  Must be valid UTF8.
+     * @param str[in, out] The string to limit.  It will be modified to
+     * the desired limit.
+     * @param utf8_size[in] How many UTF8 characters to allow.
+     * @see utf8_size() for explanation on 'UTF8 index' / size.
+     */
+    void utf8_chop_modify_at_limit(
+        std::string &str,
+        const size_t utf8_size);
+
+    /**
+     * Splits a UTF8 string into two strings.  Must be valid UTF8.
+     * @param str[in] The string to split.
+     * @param utf8_index[in] The index to split the string around.
+     * @param before_str[out] Everything before utf8_index goes here.
+     * @param after_str[out] Everything at or after utf8_index goes here.
+     * @see utf8_size() for explanation on 'UTF8 index' / size.
+     */
+    void utf8_split(
+        const std::string &str,
+        const size_t utf8_index,
+        std::string &before_str,
+        std::string &after_str);
+
+    /**
+     * Splits a UTF8 string into two strings.  Must be valid UTF8.
+     * @param str[in] The string to split.
+     * @param len[in] The length of str.
+     * @param utf8_index[in] The index to split the string around.
+     * @param before_str[out] Everything before utf8_index goes here.
+     * @param after_str[out] Everything at or after utf8_index goes here.
+     * @see utf8_size() for explanation on 'UTF8 index' / size.
+     */
+    void utf8_split(
+        const char *str,
+        const size_t len,
+        const size_t utf8_index,
+        std::string &before_str,
+        std::string &after_str);
 }
 }
 

--- a/src/utilities/mutgos_config.cpp
+++ b/src/utilities/mutgos_config.cpp
@@ -17,7 +17,12 @@
 
 #define MINIMUM_WS_MAX_INCOMING_MESSAGE_SIZE 8192
 #define MINIMUM_ANGEL_MAX_HEAP 64
+#define MINIMUM_ANGEL_MAX_STRING_LENGTH 1024
 #define MINIMUM_ANGEL_TIMESLICE 50
+#define MINIMUM_DB_STRING_LENGTH 80
+#define MINIMUM_DB_NAME_LENGTH 16
+#define MINIMUM_DB_SET_LENGTH 64
+#define MINIMUM_DB_DOCUMENT_LENGTH 64
 
 //
 // To add a new key:
@@ -85,8 +90,22 @@ namespace
     std::string config_db_file = MUTGOS_DB_DEFAULT_FILE_NAME;
     const std::string KEY_DB_PASSWORD_WORKFACTOR = "database.password_workfactor";
     MG_UnsignedInt config_db_password_workfactor = 10;
+    const std::string KEY_DB_LIMIT_STRING = "database.limits.string";
+    MG_UnsignedInt config_db_limit_string = 4096;
+    const std::string KEY_DB_LIMIT_ENTITY_NAME = "database.limits.entity.name";
+    MG_UnsignedInt config_db_limit_entity_name = 128;
+    const std::string KEY_DB_LIMIT_PLAYER_PUPPET_NAME = "database.limits.player_puppet.name";
+    MG_UnsignedInt config_db_limit_player_puppet_name = 32;
+    const std::string KEY_DB_LIMIT_PROPERTY_NAME = "database.limits.property.name";
+    MG_UnsignedInt config_db_limit_property_name = 64;
+    const std::string KEY_DB_LIMIT_PROPERTY_SET_ITEMS = "database.limits.property.set.items";
+    MG_UnsignedInt config_db_limit_property_set_items = 4096;
+    const std::string KEY_DB_LIMIT_DOCUMENT_LINES = "database.limits.property.document.lines";
+    MG_UnsignedInt config_db_limit_document_lines = 1024;
+    const std::string KEY_DB_LIMIT_PROGRAM_LINES = "database.limits.program.lines";
+    MG_UnsignedInt config_db_limit_program_lines = 32768;
 
-    // Angelscript
+    // AngelScript
     //
     const std::string KEY_ANGEL_MAX_HEAP = "angelscript.max_heap";
     MG_UnsignedInt config_angel_max_heap = 1024;
@@ -94,6 +113,8 @@ namespace
     MG_UnsignedInt config_angel_timeslice = 300;
     const std::string KEY_ANGEL_MAX_POOL_SIZE = "angelscript.max_pool_size";
     MG_UnsignedInt config_angel_max_pool_size = 4;
+    const std::string KEY_ANGEL_MAX_STRING_SIZE = "angelscript.max_string_length";
+    MG_UnsignedInt config_angel_max_string_size = 32768;
 }
 
 namespace mutgos
@@ -200,7 +221,7 @@ namespace config
         }
     }
 
-    // ----------------------------------------------------------------------
+
     /**
      * Parses the config file and sets all the file-scope variables.
      * @param config_stream[in] The config file stream to parse.
@@ -288,6 +309,27 @@ namespace config
             (KEY_DB_PASSWORD_WORKFACTOR.c_str(),
                 boost::program_options::value<MG_UnsignedInt>()->
                     default_value(config_db_password_workfactor), "")
+           (KEY_DB_LIMIT_STRING.c_str(),
+               boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_db_limit_string), "")
+           (KEY_DB_LIMIT_ENTITY_NAME.c_str(),
+               boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_db_limit_entity_name), "")
+           (KEY_DB_LIMIT_PLAYER_PUPPET_NAME.c_str(),
+               boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_db_limit_player_puppet_name), "")
+           (KEY_DB_LIMIT_PROPERTY_NAME.c_str(),
+               boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_db_limit_property_name), "")
+           (KEY_DB_LIMIT_PROPERTY_SET_ITEMS.c_str(),
+               boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_db_limit_property_set_items), "")
+           (KEY_DB_LIMIT_DOCUMENT_LINES.c_str(),
+               boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_db_limit_document_lines), "")
+           (KEY_DB_LIMIT_PROGRAM_LINES.c_str(),
+               boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_db_limit_program_lines), "")
 
             // Angelscript
             //
@@ -300,6 +342,9 @@ namespace config
             (KEY_ANGEL_MAX_POOL_SIZE.c_str(),
                 boost::program_options::value<MG_UnsignedInt>()->
                     default_value(config_angel_max_pool_size), "")
+            (KEY_ANGEL_MAX_STRING_SIZE.c_str(),
+                boost::program_options::value<MG_UnsignedInt>()->
+                    default_value(config_angel_max_string_size), "")
         ;
 
 
@@ -450,13 +495,68 @@ namespace config
                 config_db_file,
                 success);
 
-
             config_db_password_workfactor =
                 vars[KEY_DB_PASSWORD_WORKFACTOR].as<MG_UnsignedInt>();
             validate_uint(
                 KEY_DB_PASSWORD_WORKFACTOR,
                 config_db_password_workfactor,
                 success);
+
+            config_db_limit_string =
+                vars[KEY_DB_LIMIT_STRING].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_DB_LIMIT_STRING,
+                config_db_limit_string,
+                success,
+                MINIMUM_DB_STRING_LENGTH);
+
+            config_db_limit_entity_name =
+                vars[KEY_DB_LIMIT_ENTITY_NAME].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_DB_LIMIT_ENTITY_NAME,
+                config_db_limit_entity_name,
+                success,
+                MINIMUM_DB_NAME_LENGTH);
+
+            config_db_limit_player_puppet_name =
+                vars[KEY_DB_LIMIT_PLAYER_PUPPET_NAME].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_DB_LIMIT_PLAYER_PUPPET_NAME,
+                config_db_limit_player_puppet_name,
+                success,
+                MINIMUM_DB_NAME_LENGTH);
+
+            config_db_limit_property_name =
+                vars[KEY_DB_LIMIT_PROPERTY_NAME].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_DB_LIMIT_PROPERTY_NAME,
+                config_db_limit_property_name,
+                success,
+                MINIMUM_DB_NAME_LENGTH);
+
+            config_db_limit_property_set_items =
+                vars[KEY_DB_LIMIT_PROPERTY_SET_ITEMS].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_DB_LIMIT_PROPERTY_SET_ITEMS,
+                config_db_limit_property_set_items,
+                success,
+                MINIMUM_DB_SET_LENGTH);
+
+            config_db_limit_document_lines =
+                vars[KEY_DB_LIMIT_DOCUMENT_LINES].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_DB_LIMIT_DOCUMENT_LINES,
+                config_db_limit_document_lines,
+                success,
+                MINIMUM_DB_DOCUMENT_LENGTH);
+
+            config_db_limit_program_lines =
+                vars[KEY_DB_LIMIT_PROGRAM_LINES].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_DB_LIMIT_PROGRAM_LINES,
+                config_db_limit_program_lines,
+                success,
+                MINIMUM_DB_DOCUMENT_LENGTH);
 
             // Angelscript
             //
@@ -480,6 +580,14 @@ namespace config
                 KEY_ANGEL_MAX_POOL_SIZE,
                 config_angel_max_pool_size,
                 success);
+
+            config_angel_max_string_size =
+                vars[KEY_ANGEL_MAX_STRING_SIZE].as<MG_UnsignedInt>();
+            validate_uint(
+                KEY_ANGEL_MAX_STRING_SIZE,
+                config_angel_max_string_size,
+                success,
+                MINIMUM_ANGEL_MAX_STRING_LENGTH);
         }
         catch (boost::program_options::unknown_option &uoex)
         {
@@ -735,6 +843,48 @@ namespace db
     {
         return config_db_password_workfactor;
     }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt limits_string_size(void)
+    {
+        return config_db_limit_string;
+    }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt limits_entity_name(void)
+    {
+        return config_db_limit_entity_name;
+    }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt limits_player_puppet_name(void)
+    {
+        return config_db_limit_player_puppet_name;
+    }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt limits_property_name(void)
+    {
+        return config_db_limit_property_name;
+    }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt limits_property_set_items(void)
+    {
+        return config_db_limit_property_set_items;
+    }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt limits_property_document_lines(void)
+    {
+        return config_db_limit_document_lines;
+    }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt limits_program_lines(void)
+    {
+        return config_db_limit_program_lines;
+    }
 }
 
 namespace angelscript
@@ -755,6 +905,12 @@ namespace angelscript
     MG_UnsignedInt max_pool_size(void)
     {
         return config_angel_max_pool_size;
+    }
+
+    // ----------------------------------------------------------------------
+    MG_UnsignedInt max_string_size(void)
+    {
+        return config_angel_max_string_size;
     }
 }
 

--- a/src/utilities/mutgos_config.h
+++ b/src/utilities/mutgos_config.h
@@ -145,6 +145,42 @@ namespace config
          * @return The 'work factor' for database password encryption.
          */
         MG_UnsignedInt password_workfactor(void);
+
+        /**
+         * @return Default UTF8 length limit of any string in the database,
+         * unless overridden by other limits.
+         */
+        MG_UnsignedInt limits_string_size(void);
+
+        /**
+         * @return UTF8 length limit of entity name string.
+         */
+        MG_UnsignedInt limits_entity_name(void);
+
+        /**
+         * @return UTF8 length limit of player and puppet name string.
+         */
+        MG_UnsignedInt limits_player_puppet_name(void);
+
+        /**
+         * @return UTF8 length limit of property element name string.
+         */
+        MG_UnsignedInt limits_property_name(void);
+
+        /**
+         * @return Size (count) limit of items in a property set.
+         */
+        MG_UnsignedInt limits_property_set_items(void);
+
+        /**
+         * @return Line limit of property document.
+         */
+        MG_UnsignedInt limits_property_document_lines(void);
+
+        /**
+         * @return Line limit of program Documents.
+         */
+        MG_UnsignedInt limits_program_lines(void);
     }
 
 
@@ -168,6 +204,11 @@ namespace config
          * in the pool.
          */
         MG_UnsignedInt max_pool_size(void);
+
+        /**
+         * @return UTF8 maximum runtime string length.
+         */
+        MG_UnsignedInt max_string_size(void);
     }
 }
 }


### PR DESCRIPTION
Fixes #6    Fixes #7 
Incoming strings are now validated for proper UTF8.  All string indexes ( [] operator) and lengths for softcode, and certain string limits in the database, are at the code point level, not byte.

Added string size limits for all database and softcode strings, and made them data driven.

Only very basic testing was performed.  This will be wrung out more thoroughly later when the software approaches something resembling v1.0.  The idea here was to put a pattern and standard in place so it's easier to deal with later.